### PR TITLE
Automated conversion of pretty_graphs to Python 3

### DIFF
--- a/lucid/scratch/pretty_graphs/format_graph.py
+++ b/lucid/scratch/pretty_graphs/format_graph.py
@@ -316,7 +316,7 @@ def parse_graph(graph):
 def render_with_groups(seq, groups, bg_pad=6, pad_diff=8, pad_none=2):
 
   for child in seq.nodes:
-    matched_groups = [root.name for root, group_set in groups.items()
+    matched_groups = [root.name for root, group_set in list(groups.items())
                       if any(grandchild in group_set for grandchild in child.contained_nodes)]
     match_group = matched_groups[0] if matched_groups else None
     child.group = match_group
@@ -341,7 +341,7 @@ def render_with_groups(seq, groups, bg_pad=6, pad_diff=8, pad_none=2):
   # Generate groups
   used = []
   group_joined_frags = []
-  for root, group_nodes in reversed(groups.items()):
+  for root, group_nodes in reversed(list(groups.items())):
     group_frags = [frag for frag in fragments if frag.node in group_nodes]
     used += group_frags
     box = FragmentContainer(group_frags, []).box
@@ -410,7 +410,7 @@ def complete_render_model_graph(model):
   parsed_graph = parse_graph(graph)
   #parsed_graph.render().show()
   if "Resnet" in model.model_path:
-    print(parsed_graph.alignment)
+    print((parsed_graph.alignment))
     parsed_graph.alignment = "min"
 
   groups = find_groups(graph)

--- a/lucid/scratch/pretty_graphs/graph.py
+++ b/lucid/scratch/pretty_graphs/graph.py
@@ -53,7 +53,7 @@ class Graph(object):
     self.node_to_inputs[node2.name].append(node1)
 
   def __getitem__(self, index):
-    if isinstance(index, (str, unicode)):
+    if isinstance(index, str):
       return self.name_map[index]
     elif isinstance(index, Node):
       return self.name_map[index.name]
@@ -63,16 +63,16 @@ class Graph(object):
   def graphviz(self, groups=None):
     print("digraph G {")
     if groups is not None:
-        for root, group in groups.iteritems():
+        for root, group in groups.items():
           print("")
-          print("  subgraph", "cluster_%s" % root.name.replace("/", "_"), "{")
-          print("  label = \"%s\"") % (root.pretty_name or root.name)
+          print(("  subgraph", "cluster_%s" % root.name.replace("/", "_"), "{"))
+          print(("  label = \"%s\"") % (root.pretty_name or root.name))
           for node in group:
-            print("    \"%s\"") % (node.pretty_name or node.name)
+            print(("    \"%s\"") % (node.pretty_name or node.name))
           print("  }")
     for node in self.nodes:
       for inp in node.inputs:
-        print("  ", '"' + (inp.pretty_name or inp.name) + '"', " -> ", '"' + (node.pretty_name or node.name) + '"')
+        print(("  ", '"' + (inp.pretty_name or inp.name) + '"', " -> ", '"' + (node.pretty_name or node.name) + '"'))
     print("}")
 
   @staticmethod
@@ -220,7 +220,7 @@ def find_groups(graph):
     groups[root_node] = set([root_node]) | branch_uniq
     group_children |= branch_uniq
 
-  for root in groups.keys():
+  for root in list(groups.keys()):
     if root in group_children:
       del groups[root]
 

--- a/lucid/scratch/pretty_graphs/visualizations.py
+++ b/lucid/scratch/pretty_graphs/visualizations.py
@@ -112,7 +112,7 @@ def display_tooltips(node_selector, tooltip_key_attr, tooltips, container_select
 
 def get_box(render, name):
   box_map = render["node_boxes"]
-  matches = [node for node in box_map.keys() if node.name == name]
+  matches = [node for node in list(box_map.keys()) if node.name == name]
   match = matches[0]
   box = box_map[match]
   return box
@@ -133,7 +133,7 @@ def model_align_display(model1, model2, lines, middle_sep=150):
   H = shape1[1] + middle_sep + shape2[1] + 20
 
   paths = []
-  for (name1, name2), weight in lines.items():
+  for (name1, name2), weight in list(lines.items()):
     box1, box2 = get_box(render1, name1), get_box(render2, name2)
     start = [(box1[0][0]+box1[0][1])/2., shape1[1] + 15 + 10]
     end = [(box2[0][0]+box2[0][1])/2., shape1[1] + middle_sep - 10]


### PR DESCRIPTION
This was converted by `2to3`. Some idioms seem weird to me, but at least the code runs under Python 3. I'd suggest merging and cleaning up style preferences when we move this out of `/scratch`.