### PR TITLE
Allow T() to support ":" and alternate scopes.

### DIFF
--- a/lucid/optvis/render.py
+++ b/lucid/optvis/render.py
@@ -249,13 +249,16 @@ def make_optimizer(optimizer, args):
            "optimizer, or tf.train.Optimizer instance.")
 
 
-def import_model(model, t_image, t_image_raw):
+def import_model(model, t_image, t_image_raw, scope="import"):
 
-  model.import_graph(t_image, scope="import", forget_xy_shape=True)
+  model.import_graph(t_image, scope=scope, forget_xy_shape=True)
 
   def T(layer):
     if layer == "input": return t_image_raw
     if layer == "labels": return model.labels
-    return t_image.graph.get_tensor_by_name("import/%s:0"%layer)
+    if ":" in layer:
+        return t_image.graph.get_tensor_by_name("%s/%s" % (scope,layer))
+    else:
+        return t_image.graph.get_tensor_by_name("%s/%s:0" % (scope,layer))
 
   return T


### PR DESCRIPTION
`T()` is used in lucid to access TensorFlow layers and nodes.
Previously, `T("name")` would be inferred to refer to `import/name:0`,
which didn't allow us to support scopes other than `import` or
tensors that weren't the first output of an op.

This commit should be fully backwards compatible.