### PR TITLE
Add Synset support for ImageNet models.

### DIFF
--- a/lucid/modelzoo/caffe_models/InceptionV1.py
+++ b/lucid/modelzoo/caffe_models/InceptionV1.py
@@ -28,6 +28,7 @@ class InceptionV1_caffe(Model):
   """
   model_path = 'gs://modelzoo/vision/caffe_models/InceptionV1.pb'
   labels_path = 'gs://modelzoo/labels/ImageNet_standard.txt'
+  synsets_path = 'gs://modelzoo/labels/ImageNet_standard_synsets.txt'
   dataset = 'ImageNet'
   image_shape = [224, 224, 3]
   is_BGR = True

--- a/lucid/modelzoo/caffe_models/others.py
+++ b/lucid/modelzoo/caffe_models/others.py
@@ -25,6 +25,7 @@ class CaffeNet_caffe(Model):
 
   model_path  = 'gs://modelzoo/vision/caffe_models/CaffeNet.pb'
   labels_path = 'gs://modelzoo/labels/ImageNet_standard.txt'
+  synsets_path = 'gs://modelzoo/labels/ImageNet_standard_synsets.txt'
   dataset = 'ImageNet'
   image_shape = [227, 227, 3]
   is_BGR = True
@@ -53,6 +54,7 @@ class VGG16_caffe(Model):
   """
   model_path = 'gs://modelzoo/vision/caffe_models/VGG16.pb'
   labels_path = 'gs://modelzoo/labels/ImageNet_standard.txt'
+  synsets_path = 'gs://modelzoo/labels/ImageNet_standard_synsets.txt'
   dataset = 'ImageNet'
   image_shape = [224, 224, 3]
   is_BGR = True
@@ -92,6 +94,7 @@ class VGG19_caffe(Model):
   """
   model_path = 'gs://modelzoo/vision/caffe_models/VGG19.pb'
   labels_path = 'gs://modelzoo/labels/ImageNet_standard.txt'
+  synsets_path = 'gs://modelzoo/labels/ImageNet_standard_synsets.txt'
   dataset = 'ImageNet'
   image_shape = [224, 224, 3]
   is_BGR = True

--- a/lucid/modelzoo/other_models/AlexNet.py
+++ b/lucid/modelzoo/other_models/AlexNet.py
@@ -34,6 +34,7 @@ class AlexNet(Model):
   # but it seems more polite and reliable to host our own.
   model_path  = 'gs://modelzoo/vision/other_models/AlexNet.pb'
   labels_path = 'gs://modelzoo/labels/ImageNet_standard.txt'
+  synsets_path = 'gs://modelzoo/labels/ImageNet_standard_synsets.txt'
   dataset = 'ImageNet'
   image_shape = [227, 227, 3]
   is_BGR = True

--- a/lucid/modelzoo/other_models/InceptionV1.py
+++ b/lucid/modelzoo/other_models/InceptionV1.py
@@ -50,6 +50,7 @@ class InceptionV1(Model):
   """
   model_path = 'gs://modelzoo/vision/other_models/InceptionV1.pb'
   labels_path = 'gs://modelzoo/labels/ImageNet_alternate.txt'
+  synsets_path = 'gs://modelzoo/labels/ImageNet_alternate_synsets.txt'
   dataset = 'ImageNet'
   image_shape = [224, 224, 3]
   image_value_range = (-117, 255-117)

--- a/lucid/modelzoo/slim_models/Inception.py
+++ b/lucid/modelzoo/slim_models/Inception.py
@@ -29,6 +29,7 @@ class InceptionV1_slim(Model):
   layers = None
   model_path  = 'gs://modelzoo/vision/slim_models/InceptionV1.pb'
   labels_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy.txt'
+  synsets_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy_synsets.txt'
   dataset = 'ImageNet'
   image_shape = [224, 224, 3]
   # inpute range taken from:
@@ -64,6 +65,7 @@ class InceptionV2_slim(Model):
 
   model_path  = 'gs://modelzoo/vision/slim_models/InceptionV2.pb'
   labels_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy.txt'
+  synsets_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy_synsets.txt'
   dataset = 'ImageNet'
   image_shape = [224, 224, 3]
   # inpute range taken from:
@@ -101,6 +103,7 @@ class InceptionV3_slim(Model):
 
   model_path  = 'gs://modelzoo/vision/slim_models/InceptionV3.pb'
   labels_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy.txt'
+  synsets_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy_synsets.txt'
   dataset = 'ImageNet'
   image_shape = [299, 299, 3]
   # inpute range taken from:
@@ -141,6 +144,7 @@ class InceptionV4_slim(Model):
 
   model_path  = 'gs://modelzoo/vision/slim_models/InceptionV4.pb'
   labels_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy.txt'
+  synsets_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy_synsets.txt'
   dataset = 'ImageNet'
   image_shape = [299, 299, 3]
   # inpute range taken from:
@@ -187,6 +191,7 @@ class InceptionResnetV2_slim(Model):
 
   model_path  = 'gs://modelzoo/vision/slim_models/InceptionResnetV2.pb'
   labels_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy.txt'
+  synsets_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy_synsets.txt'
   dataset = 'ImageNet'
   image_shape = [299, 299, 3]
   # inpute range taken from:

--- a/lucid/modelzoo/slim_models/MobilenetV1.py
+++ b/lucid/modelzoo/slim_models/MobilenetV1.py
@@ -25,6 +25,7 @@ class MobilenetV1_slim(Model):
 
   model_path  = 'gs://modelzoo/vision/slim_models/MobilenetV1.pb'
   labels_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy.txt' #TODO
+  synsets_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy_synsets.txt'
   dataset = 'ImageNet'
   image_shape = [224, 224, 3]
   # inpute range taken from:
@@ -62,6 +63,7 @@ class MobilenetV1_050_slim(Model):
 
   model_path  = 'gs://modelzoo/vision/slim_models/MobilenetV1050.pb'
   labels_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy.txt' #TODO
+  synsets_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy_synsets.txt'
   dataset = 'ImageNet'
   image_shape = [224, 224, 3]
   # inpute range taken from:
@@ -99,6 +101,7 @@ class MobilenetV1_025_slim(Model):
 
   model_path  = 'gs://modelzoo/vision/slim_models/MobilenetV1025.pb'
   labels_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy.txt' #TODO
+  synsets_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy_synsets.txt'
   dataset = 'ImageNet'
   image_shape = [224, 224, 3]
   # inpute range taken from:

--- a/lucid/modelzoo/slim_models/MobilenetV2.py
+++ b/lucid/modelzoo/slim_models/MobilenetV2.py
@@ -25,6 +25,7 @@ class MobilenetV2_10_slim(Model):
 
   model_path  = 'gs://modelzoo/vision/slim_models/MobilenetV2_10.pb'
   labels_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy.txt'
+  synsets_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy_synsets.txt'
   dataset = 'ImageNet'
   image_shape = [224, 224, 3]
   # inpute range taken from:
@@ -56,6 +57,7 @@ class MobilenetV2_14_slim(Model):
 
   model_path  = 'gs://modelzoo/vision/slim_models/MobilenetV2_14.pb'
   labels_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy.txt'
+  synsets_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy_synsets.txt'
   dataset = 'ImageNet'
   image_shape = [224, 224, 3]
   # inpute range taken from:

--- a/lucid/modelzoo/slim_models/ResNetV1.py
+++ b/lucid/modelzoo/slim_models/ResNetV1.py
@@ -26,6 +26,7 @@ class ResnetV1_50_slim(Model):
 
   model_path  = 'gs://modelzoo/vision/slim_models/ResnetV1_50.pb'
   labels_path = 'gs://modelzoo/labels/ImageNet_standard.txt'
+  synsets_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy_synsets.txt'
   dataset = 'ImageNet'
   image_shape = [224, 224, 3]
 
@@ -66,6 +67,7 @@ class ResnetV1_101_slim(Model):
 
   model_path  = 'gs://modelzoo/vision/slim_models/ResnetV1_101.pb'
   labels_path = 'gs://modelzoo/labels/ImageNet_standard.txt'
+  synsets_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy_synsets.txt'
   dataset = 'ImageNet'
   image_shape = [224, 224, 3]
   image_value_range = (-117, 255-117) # Inferred by testing, may not be exactly right
@@ -122,6 +124,7 @@ class ResnetV1_152_slim(Model):
 
   model_path  = 'gs://modelzoo/vision/slim_models/ResnetV1_152.pb'
   labels_path = 'gs://modelzoo/labels/ImageNet_standard.txt'
+  synsets_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy_synsets.txt'
   dataset = 'ImageNet'
   image_shape = [224, 224, 3]
   image_value_range = (-117, 255-117) # Inferred by testing, may not be exactly right

--- a/lucid/modelzoo/slim_models/ResNetV2.py
+++ b/lucid/modelzoo/slim_models/ResNetV2.py
@@ -29,6 +29,7 @@ class ResnetV2_50_slim(Model):
 
   model_path  = 'gs://modelzoo/vision/slim_models/ResnetV2_50.pb'
   labels_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy.txt'
+  synsets_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy_synsets.txt'
   dataset = 'ImageNet'
   image_shape = [224, 224, 3]
   # inpute range taken from:
@@ -74,6 +75,7 @@ class ResnetV2_101_slim(Model):
 
   model_path  = 'gs://modelzoo/vision/slim_models/ResnetV2_101.pb'
   labels_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy.txt'
+  synsets_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy_synsets.txt'
   dataset = 'ImageNet'
   image_shape = [224, 224, 3]
   # inpute range taken from:
@@ -136,6 +138,7 @@ class ResnetV2_152_slim(Model):
 
   model_path  = 'gs://modelzoo/vision/slim_models/ResnetV2_152.pb'
   labels_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy.txt'
+  synsets_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy_synsets.txt'
   dataset = 'ImageNet'
   image_shape = [224, 224, 3]
   # inpute range taken from:

--- a/lucid/modelzoo/slim_models/others.py
+++ b/lucid/modelzoo/slim_models/others.py
@@ -37,6 +37,7 @@ from lucid.modelzoo.vision_base import Model, _layers_from_list_of_dicts, IMAGEN
 #
 #   model_path  = 'gs://modelzoo/VGG16.pb'
 #   labels_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy.txt' #TODO
+#   synsets_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy_synsets.txt'
 #   dataset = 'ImageNet'
 #   image_shape = [224, 224, 3]
 #   image_value_range = (-1, 1)
@@ -73,6 +74,7 @@ from lucid.modelzoo.vision_base import Model, _layers_from_list_of_dicts, IMAGEN
 #
 #   model_path  = 'gs://modelzoo/VGG19.pb'
 #   labels_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy.txt' #TODO
+#   synsets_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy_synsets.txt'
 #   dataset = 'ImageNet'
 #   image_shape = [224, 224, 3]
 #   image_value_range = (-1, 1)
@@ -109,6 +111,7 @@ class NasnetMobile_slim(Model):
 
   model_path  = 'gs://modelzoo/vision/slim_models/NasnetMobile.pb'
   labels_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy.txt' #TODO
+  synsets_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy_synsets.txt'
   dataset = 'ImageNet'
   image_shape = [224, 224, 3]
   # inpute range taken from:
@@ -193,6 +196,7 @@ class PnasnetMobile_slim(Model):
 
   model_path  = 'gs://modelzoo/vision/slim_models/PnasnetMobile.pb'
   labels_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy.txt' #TODO
+  synsets_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy_synsets.txt'
   dataset = 'ImageNet'
   image_shape = [224, 224, 3]
   # inpute range taken from:
@@ -226,6 +230,7 @@ class PnasnetLarge_slim(Model):
 
   model_path  = 'gs://modelzoo/vision/slim_models/PnasnetLarge.pb'
   labels_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy.txt' #TODO
+  synsets_path = 'gs://modelzoo/labels/ImageNet_standard_with_dummy_synsets.txt'
   dataset = 'ImageNet'
   image_shape = [331, 331, 3]
   # inpute range taken from:

--- a/lucid/modelzoo/vision_base.py
+++ b/lucid/modelzoo/vision_base.py
@@ -110,9 +110,9 @@ class Model(with_metaclass(ModelPropertiesMetaClass, object)):
 
   def __init__(self):
     self.graph_def = None
-    if self.labels_path is not None:
+    if hasattr(self, 'labels_path') and self.labels_path is not None:
       self.labels = load_text_labels(self.labels_path)
-    if self.synsets_path is not None:
+    if hasattr(self, 'synsets_path') and self.synsets_path is not None:
       self.synsets = load_text_labels(self.synsets_path)
       # If NLTK WordNet is available, provide synsets in that form as well.
       if wordnet is not None:

--- a/lucid/modelzoo/vision_base.py
+++ b/lucid/modelzoo/vision_base.py
@@ -27,6 +27,15 @@ from lucid.modelzoo.aligned_activations import get_aligned_activations as _get_a
 from lucid.misc.io import load
 import lucid.misc.io.showing as showing
 
+# ImageNet classes correspond to WordNet Synsets.
+# If NLTK and the WordNet corpus are installed, we can support
+# interoperability in a few places.
+try:
+    from nltk.corpus import wordnet
+except:
+    wordnet = None
+
+
 IMAGENET_MEAN = np.array([123.68, 116.779, 103.939])
 IMAGENET_MEAN_BGR = np.flip(IMAGENET_MEAN, 0)
 
@@ -103,6 +112,14 @@ class Model(with_metaclass(ModelPropertiesMetaClass, object)):
     self.graph_def = None
     if self.labels_path is not None:
       self.labels = load_text_labels(self.labels_path)
+    if self.synsets_path is not None:
+      self.synsets = load_text_labels(self.synsets_path)
+      # If NLTK WordNet is available, provide synsets in that form as well.
+      if wordnet is not None:
+          def get_synset(id_str):
+              pos, offset = id_str[0], int(id_str[1:])
+              return wordnet.synset_from_pos_and_offset(pos, offset)
+          self.nltk_synsets = [get_synset(id) for id in self.synsets]
 
   @property
   def name(self):


### PR DESCRIPTION
Allow ImageNet model classes to be reference by ImageNet Synsets,
in addition to human readable names. This is helpful for model comparison,
where models may use different label strings and orders.

We also provide interoperability with the NLTK WordNet Synset API.