### PR TITLE
`show()` enhancements

### DIFF
--- a/lucid/misc/io/collapse_channels.py
+++ b/lucid/misc/io/collapse_channels.py
@@ -1,0 +1,65 @@
+# Copyright 2018 The Lucid Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Convert an "image" wtih n channels into 3 RGB channels."""
+
+
+import math
+import numpy as np
+
+def hue_to_rgb(ang):
+  """Produce an RGB unit vector corresponding to a hue of a given angle."""
+  ang = ang - 360*(ang//360)
+  colors = np.asarray([
+      [1,0,0],
+      [1,1,0],
+      [0,1,0],
+      [0,1,1],
+      [0,0,1],
+      [1,0,1],
+  ])
+  colors = colors / np.linalg.norm(colors, axis=1, keepdims=True)
+  R = 360 / len(colors)
+  n = math.floor(ang / R)
+  D = (ang - n*R) / R
+
+  v = (1-D) * colors[n] + D * colors[(n+1) % len(colors)]
+  return v / np.linalg.norm(v)
+
+
+def sparse_channels_to_rgb(X):
+  assert (X >= 0).all()
+
+  K = X.shape[-1]
+
+  rgb = 0
+  for i in range(K):
+    ang = 360 * i / K
+    color = hue_to_rgb(ang)
+    color = color[tuple(None for _ in range(len(X.shape)-1))]
+    rgb += X[..., i, None] * color
+
+  rgb += np.ones(X.shape[:-1])[..., None] * (X.sum(-1) - X.max(-1))[..., None]
+  rgb /= 1e-4 + np.linalg.norm(rgb, axis=-1, keepdims=True)
+  rgb *= np.linalg.norm(X, axis=-1, keepdims=True)
+
+  return rgb
+
+
+def collapse_channels(X):
+
+  if (X < 0).any():
+    X = np.concatenate([np.maximum(0, X), np.maximum(0, -X)], axis=-1)
+  return sparse_channels_to_rgb(X)


### PR DESCRIPTION
This PR makes a few small enhancements to `show()`:

* Fix handling of the `w` argument for both `showing.image` and `showing.images`. This fixes case(1) of #26. This is an extremely common use case and annoying to work around.

![image](https://user-images.githubusercontent.com/61658/58292361-e3eb3900-7d75-11e9-9479-85040845229e.png)

* Fix second half of #26, handling of `domain` through `images()`.

* Handle images with 2 or >3 channels by collapsing them as in the Neuron Groups visualization of Building Blocks. This makes it easier to work with `ChannelReducer()` and similar tools. It also shows magnitude if used uses it to show activations directly.

![image](https://user-images.githubusercontent.com/61658/58292573-afc44800-7d76-11e9-925b-2e525713bf89.png)
