### PR TITLE
fix objectives.wrap_objective decorator usage

### DIFF
--- a/lucid/recipes/activation_atlas/render.py
+++ b/lucid/recipes/activation_atlas/render.py
@@ -28,7 +28,7 @@ import lucid.optvis.render as render
 import lucid.optvis.transform as transform
 
 
-@objectives.wrap_objective
+@objectives.wrap_objective()
 def direction_neuron_S(layer_name, vec, batch=None, x=None, y=None, S=None):
     def inner(T):
         layer = T(layer_name)
@@ -50,7 +50,7 @@ def direction_neuron_S(layer_name, vec, batch=None, x=None, y=None, S=None):
     return inner
 
 
-@objectives.wrap_objective
+@objectives.wrap_objective()
 def direction_neuron_cossim_S(
     layer_name, vec, batch=None, x=None, y=None, cossim_pow=2, S=None
 ):

--- a/lucid/recipes/caricature.py
+++ b/lucid/recipes/caricature.py
@@ -17,7 +17,7 @@ import lucid.misc.io.showing
 from lucid.modelzoo.vision_base import SerializedModel
 
 
-@objectives.wrap_objective
+@objectives.wrap_objective()
 def dot_compare(layer, batch=1, cossim_pow=0):
   def inner(T):
     acts1 = T(layer)[0]


### PR DESCRIPTION
In the current implementation of `objectives.wrap_objective` you need to call the decorator when applying it to a function, otherwise it will not be applied correctly.