### PR TITLE
skip control inputs when building graphs

### DIFF
--- a/lucid/misc/graph_analysis/overlay_graph.py
+++ b/lucid/misc/graph_analysis/overlay_graph.py
@@ -162,6 +162,8 @@ class OverlayGraph():
 
     overlay_inps = []
     for inp in raw_inps:
+      if inp.startswith('^'):  # skip control inputs
+        continue
       if inp in self:
         overlay_inps.append(self[inp])
       elif not node.name in self.no_pass_through:

--- a/lucid/scratch/pretty_graphs/graph.py
+++ b/lucid/scratch/pretty_graphs/graph.py
@@ -85,6 +85,8 @@ class Graph(object):
 
     for raw_node in graphdef.node:
       for raw_inp in raw_node.input:
+        if raw_inp.startswith('^'):  # skip control inputs
+          continue
         raw_inp_name = raw_inp.split(":")[0]
         graph.add_edge(raw_inp_name, raw_node.name)
 


### PR DESCRIPTION
Control inputs are not attached to the graph in a way that makes them visible when iterating using `graphdef.node`. This causes a crash when trying to attach them as an edge. For now, skipping them seems like a reasonable way to keep the graphs working.