### PR TITLE
Allow for parametrized classes

### DIFF
--- a/lucid/modelzoo/vision_base.py
+++ b/lucid/modelzoo/vision_base.py
@@ -145,12 +145,15 @@ class Model():
   @property
   def name(self):
     if self.modelname == None:
-      return self.__class__.name
+      return self.__class__.__name__
     else:
       return self.modelname
 
   def __str__(self):
-    return self.__class__.name
+    if self.modelname == None:
+      return self.__class__.__name__
+    else:
+      return self.modelname
 
   def to_json(self):
     return self.name  # TODO

--- a/lucid/modelzoo/vision_base.py
+++ b/lucid/modelzoo/vision_base.py
@@ -14,7 +14,6 @@
 # ==============================================================================
 
 from __future__ import absolute_import, division, print_function
-from future.utils import with_metaclass
 from os import path
 import warnings
 import logging
@@ -95,7 +94,7 @@ class Model():
   image_value_range = (-1, 1)
   image_shape = (None, None, 3)
   layers = ()
-  modelname = None
+  model_name = None
 
   _labels = None
   _synset_ids = None
@@ -144,16 +143,13 @@ class Model():
 
   @property
   def name(self):
-    if self.modelname == None:
+    if self.model_name == None:
       return self.__class__.__name__
     else:
-      return self.modelname
+      return self.model_name
 
   def __str__(self):
-    if self.modelname == None:
-      return self.__class__.__name__
-    else:
-      return self.modelname
+    return self.name
 
   def to_json(self):
     return self.name  # TODO

--- a/lucid/modelzoo/vision_base.py
+++ b/lucid/modelzoo/vision_base.py
@@ -87,14 +87,7 @@ def _layers_from_list_of_dicts(model_class, list_of_dicts):
   return tuple(layers)
 
 
-class ModelPropertiesMetaClass(type):
-
-  @property
-  def name(cls):
-      return cls.__name__
-
-
-class Model(with_metaclass(ModelPropertiesMetaClass, object)):
+class Model():
   """Model allows using pre-trained models."""
 
   model_path = None
@@ -102,6 +95,7 @@ class Model(with_metaclass(ModelPropertiesMetaClass, object)):
   image_value_range = (-1, 1)
   image_shape = (None, None, 3)
   layers = ()
+  modelname = None
 
   _labels = None
   _synset_ids = None
@@ -150,7 +144,10 @@ class Model(with_metaclass(ModelPropertiesMetaClass, object)):
 
   @property
   def name(self):
-    return self.__class__.name
+    if self.modelname == None:
+      return self.__class__.name
+    else:
+      return self.modelname
 
   def __str__(self):
     return self.__class__.name


### PR DESCRIPTION
Currently, models with custom names, e.g.

```python
class MichaelModel_Final_Base(Model):
    model_path = f'gs://clarity-public/michael/graphs/inceptionv1-base/frozen-{checkpoint}.pb'
    image_shape = [224, 224, 3]
    image_value_range = (0, 1)
    input_name = 'v0/model/input_images'
    name = "Name"
```

 cannot be serialized and passed into dask. This PR fixes this.