### PR TITLE
hue_to_rgb warping

### DIFF
--- a/lucid/misc/io/collapse_channels.py
+++ b/lucid/misc/io/collapse_channels.py
@@ -19,7 +19,7 @@
 import math
 import numpy as np
 
-def hue_to_rgb(ang):
+def hue_to_rgb(ang, warp=True):
   """Produce an RGB unit vector corresponding to a hue of a given angle."""
   ang = ang - 360*(ang//360)
   colors = np.asarray([
@@ -34,6 +34,15 @@ def hue_to_rgb(ang):
   R = 360 / len(colors)
   n = math.floor(ang / R)
   D = (ang - n*R) / R
+
+  if warp:
+    # warping the angle away from the primary colors (RGB)
+    # helps make equally-spaced angles more visually distinguishable
+    adj = lambda x: math.sin(x * math.pi / 2)
+    if n % 2 == 0:
+      D = adj(D)
+    else:
+      D = 1 - adj(1 - D)
 
   v = (1-D) * colors[n] + D * colors[(n+1) % len(colors)]
   return v / np.linalg.norm(v)


### PR DESCRIPTION
Makes a subtle change to the `hue_to_rgb` that should make the colors produced by `collapse_channels` more visually distinguishable.

It's based on the observation that as you move through the hue axis of HSV color space, the color seems (to me) to change more quickly around the midpoints between the primary colors (RGB). The fix therefore adjusts the hue to move more slowly through these midpoints.

Here's a before and after of the hues used by `collapse_channels` with 1, ..., 18 channels (with full saturation and value). The change makes the most practical difference with 7, 8 or 9 channels, where there are two or three very similar greens before that are easier to distinguish after.

<img width="1827" alt="Screenshot 2019-09-18 at 15 39 29" src="https://user-images.githubusercontent.com/5995779/65192000-95e7f880-da2a-11e9-8169-96ffef0db13b.png">

There's probably more tweaking that could be done to e.g. make better use of orange and yellow, but this simple change seems to get most of the way there.
