### PR TITLE
More defensive Model.save()

### DIFF
--- a/lucid/modelzoo/util.py
+++ b/lucid/modelzoo/util.py
@@ -62,7 +62,12 @@ def frozen_default_graph_def(input_node_names, output_node_names):
   """Return frozen and simplified graph_def of default graph."""
 
   sess = tf.get_default_session()
+  if sess is None:
+    raise RuntimeError("Default session not registered.")
+
   input_graph_def = tf.get_default_graph().as_graph_def()
+  if len(input_graph_def.node) == 0:
+    raise RuntimeError("Default graph is empty. Is it possible your model wasn't constructed or is in a different graph?")
 
   pruned_graph = tf.graph_util.remove_training_nodes(
       input_graph_def, protected_nodes=(output_node_names + input_node_names)

--- a/lucid/modelzoo/vision_base.py
+++ b/lucid/modelzoo/vision_base.py
@@ -297,6 +297,11 @@ class Model(with_metaclass(ModelPropertiesMetaClass, object)):
 
   @staticmethod
   def save(save_url, input_name, output_names, image_shape, image_value_range):
+    if ":" in input_name:
+      raise ValueError("input_name appears to be a tensor (name contains ':') but must be an op.")
+    if any([":" in name for name in output_names]):
+      raise ValueError("output_namess appears to be contain tensor (name contains ':') but must be ops.")
+
     metadata = {
       "input_name" : input_name,
       "image_shape" : image_shape,


### PR DESCRIPTION
Importing models is a common failure point for users. This PR implements suggestions from  #188 to more defensively implement model saving and catch some common errors.