### PR TITLE
Adding batch load and save to misc.io

### DIFF
--- a/lucid/misc/io/__init__.py
+++ b/lucid/misc/io/__init__.py
@@ -1,4 +1,4 @@
 from lucid.misc.io.showing import show
 from lucid.misc.io.loading import load
-from lucid.misc.io.saving import save, CaptureSaveContext
+from lucid.misc.io.saving import save, CaptureSaveContext, batch_save
 from lucid.misc.io.scoping import io_scope, scope_url

--- a/lucid/misc/io/saving.py
+++ b/lucid/misc/io/saving.py
@@ -26,19 +26,14 @@ intended serializations from the URL's file extension.
 Possible extension: if not given a URL this could create one and return it?
 """
 
-from __future__ import absolute_import, division, print_function
-
 import logging
 import subprocess
 import warnings
 import threading
-from copy import copy
-
-# from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
 import os.path
 import json
-from typing import Optional, List
-
+from typing import Optional, List, Tuple
 import numpy as np
 import PIL.Image
 
@@ -273,3 +268,21 @@ def save(thing, url_or_handle, save_context: Optional[CaptureSaveContext] = None
         result["serve"] = "https://storage.googleapis.com/{}".format(result["url"][5:])
 
     return result
+
+
+def batch_save(save_ops: List[Tuple], num_workers: int = 16):
+    caller_io_scopes = current_io_scopes()
+    current_save_context = CaptureSaveContext.current_save_context()
+
+    def _do_save(save_op_tuple: Tuple):
+        set_io_scopes(caller_io_scopes)
+        if len(save_op_tuple) == 2:
+            return save(save_op_tuple[0], save_op_tuple[1], save_context=current_save_context)
+        elif len(save_op_tuple) == 3:
+            return save(save_op_tuple[0], save_op_tuple[1], save_context=current_save_context, **(save_op_tuple[2]))
+        else:
+            raise ValueError(f'unknown save tuple size: {len(save_op_tuple)}')
+
+    with ThreadPoolExecutor(max_workers=num_workers) as executor:
+        save_op_futures = [executor.submit(_do_save, save_op_tuple) for save_op_tuple in save_ops]
+        return [future.result() for future in save_op_futures]

--- a/tests/misc/io/test_loading.py
+++ b/tests/misc/io/test_loading.py
@@ -1,12 +1,22 @@
 # -*- coding: UTF-8 -*-
 from __future__ import absolute_import, division, print_function
 
+import os
+
 import pytest
 
 import numpy as np
 from lucid.misc.io.loading import load
+from lucid.misc.io.scoping import io_scope
 import io
 
+test_images = [
+    "./tests/fixtures/rgbeye.png",
+    "./tests/fixtures/noise_uppercase.PNG",
+    "./tests/fixtures/rgbeye.jpg",
+    "./tests/fixtures/noise.jpeg",
+    "./tests/fixtures/image.xyz",
+]
 
 def test_load_json():
   path = "./tests/fixtures/dictionary.json"
@@ -39,13 +49,7 @@ def test_load_npz():
   assert isinstance(arrays, np.lib.npyio.NpzFile)
 
 
-@pytest.mark.parametrize("path", [
-  "./tests/fixtures/rgbeye.png",
-  "./tests/fixtures/noise_uppercase.PNG",
-  "./tests/fixtures/rgbeye.jpg",
-  "./tests/fixtures/noise.jpeg",
-  "./tests/fixtures/image.xyz",
-])
+@pytest.mark.parametrize("path", test_images)
 def test_load_image(path):
   image = load(path)
   assert image.shape is not None
@@ -79,3 +83,13 @@ def test_load_protobuf():
   path = "./tests/fixtures/graphdef.pb"
   graphdef = load(path)
   assert "int_val: 42" in repr(graphdef)
+
+
+def test_batch_load():
+    image_names = [os.path.basename(image) for image in test_images]
+    with io_scope('./tests/fixtures'):
+        images = load(image_names)
+    assert len(images) == len(test_images)
+    for i in range(len(test_images)):
+        assert np.allclose(load(test_images[i]), images[i])
+


### PR DESCRIPTION
This allows much faster saving and loading of data if you know the URLs ahead of time. A thread pool executor is used to parallelize io and network operations.