### PR TITLE
Add support for saving/loading compressed data + pickle support

### DIFF
--- a/lucid/misc/io/loading.py
+++ b/lucid/misc/io/loading.py
@@ -24,6 +24,8 @@ This should support for example PNG images, JSON files, npy files, etc.
 import os
 import json
 import logging
+import pickle
+
 import numpy as np
 import PIL.Image
 import tensorflow as tf
@@ -132,6 +134,11 @@ def _load_graphdef_protobuf(handle, **kwargs):
     return graph_def
 
 
+def _load_pickle(handle, **kwargs):
+  """Load a pickled python object."""
+  return pickle.load(handle, **kwargs)
+
+
 loaders = {
     ".png": _load_img,
     ".jpg": _load_img,
@@ -142,6 +149,8 @@ loaders = {
     ".txt": _load_text,
     ".md": _load_text,
     ".pb": _load_graphdef_protobuf,
+    ".pickle": _load_pickle,
+    ".pkl": _load_pickle,
 }
 
 

--- a/lucid/misc/io/saving.py
+++ b/lucid/misc/io/saving.py
@@ -27,6 +27,7 @@ Possible extension: if not given a URL this could create one and return it?
 """
 
 import logging
+import pickle
 import subprocess
 import warnings
 import threading
@@ -186,6 +187,14 @@ def save_pb(object, handle, **kwargs):
         return {"type": "pb", "url": handle.name}
 
 
+def save_pickle(object, handle, **kwargs):
+  try:
+    pickle.dump(object, handle)
+  except AttributeError as e:
+    warnings.warn("`save_pickle` failed for object {}. Re-raising original exception.".format(object))
+    raise e
+
+
 savers = {
     ".png": save_img,
     ".jpg": save_img,
@@ -196,6 +205,8 @@ savers = {
     ".json": save_json,
     ".txt": save_txt,
     ".pb": save_pb,
+    ".pickle": save_pickle,
+    ".pkl": save_pickle,
 }
 
 

--- a/lucid/misc/io/saving.py
+++ b/lucid/misc/io/saving.py
@@ -216,6 +216,9 @@ savers = {
     ".json": save_json,
     ".txt": save_txt,
     ".pb": save_pb,
+}
+
+unsafe_savers = {
     ".pickle": save_pickle,
     ".pkl": save_pickle,
 }
@@ -225,7 +228,7 @@ compressors = {
 }
 
 
-def save(thing, url_or_handle, save_context: Optional[CaptureSaveContext] = None, **kwargs):
+def save(thing, url_or_handle, allow_unsafe_formats=False, save_context: Optional[CaptureSaveContext] = None, **kwargs):
     """Save object to file on CNS.
 
     File format is inferred from path. Use save_img(), save_npy(), or save_json()
@@ -234,6 +237,8 @@ def save(thing, url_or_handle, save_context: Optional[CaptureSaveContext] = None
     Args:
       obj: object to save.
       path: CNS path.
+      allow_unsafe_formats: set to True to allow saving unsafe formats (eg. pickles)
+      save_context: a context into which to capture saves, otherwise will try to use global context
 
     Raises:
       RuntimeError: If file extension not supported.
@@ -262,6 +267,10 @@ def save(thing, url_or_handle, save_context: Optional[CaptureSaveContext] = None
     # Determine which saver should be used
     if ext in savers:
         saver = savers[ext]
+    elif ext in unsafe_savers:
+        if not allow_unsafe_formats:
+            raise ValueError(f"{ext} is considered unsafe, you must explicitly allow its use by passing allow_unsafe_formats=True")
+        saver = unsafe_savers[ext]
     elif isinstance(thing, str):
         saver = save_str
     else:

--- a/tests/misc/io/test_saving.py
+++ b/tests/misc/io/test_saving.py
@@ -103,16 +103,6 @@ def test_save_named_handle():
     assert os.path.isfile(path)
 
 
-def test_unknown_extension():
-    with pytest.raises(ValueError):
-        save({}, "test.unknown")
-
-
-def test_unknown_compressor():
-    with pytest.raises(ValueError):
-        save(array2, "test.npy.gz")  # .gz is not currently supported, only xy
-
-
 def test_save_compressed_npy():
     uncompressed_path = "./tests/fixtures/generated_outputs/array.npy"
     _remove(uncompressed_path)
@@ -127,6 +117,35 @@ def test_save_compressed_npy():
     uncompressed_size = os.path.getsize(uncompressed_path)
     compressed_size = os.path.getsize(compressed_path)
     assert compressed_size < uncompressed_size
+
+
+def test_save_load_pickle():
+    path = "./tests/fixtures/generated_outputs/some_data.pickle"
+    data = {
+        'test': [1, 2, 3, "some string"],
+        'numpy_values': array2
+    }
+    _remove(path)
+    with io.open(path, "wb") as handle:
+        with pytest.raises(ValueError):
+            save(data, handle)
+        save(data, handle, allow_unsafe_formats=True)
+    assert os.path.isfile(path)
+    with pytest.raises(ValueError):
+        loaded_data = load(path)
+    loaded_data = load(path, allow_unsafe_formats=True)
+    assert loaded_data['test'] == data['test']
+    assert np.array_equal(loaded_data['numpy_values'], data['numpy_values'])
+
+
+def test_unknown_extension():
+    with pytest.raises(ValueError):
+        save({}, "test.unknown")
+
+
+def test_unknown_compressor():
+    with pytest.raises(ValueError):
+        save(array2, "test.npy.gz")  # .gz is not currently supported, only xy
 
 
 def test_save_protobuf():


### PR DESCRIPTION
- adds support for saving and loading xz/lzma compressed data by allowing any format to end in `.xz`
- adds support for loading `.pkl` and `.pickle` files, but only when `allow_unsafe_formats=True` is passed into the loading/saving function. this will hopefully mean that this functionality will never be used with user input by accident. In some hand picked scripts I want to be able to save and load pickles (to cache complicated data structures), and in those cases I will pass `allow_unsafe_format=True` and load the data from a trusted source only.