### PR TITLE
Parameter editor fixes

### DIFF
--- a/lucid/scratch/parameter_editor.py
+++ b/lucid/scratch/parameter_editor.py
@@ -4,11 +4,14 @@ import tensorflow as tf
 
 class ParameterEditor():
   """Conveniently edit the parameters of a lucid model.
+
   Example usage:
+
     model = models.InceptionV1()
     param = ParameterEditor(model.graph_def)
     # Flip weights of first channel of conv2d0
     param["conv2d0_w", :, :, :, 0] *= -1
+
   """
 
   def __init__(self, graph_def):

--- a/lucid/scratch/parameter_editor.py
+++ b/lucid/scratch/parameter_editor.py
@@ -4,14 +4,11 @@ import tensorflow as tf
 
 class ParameterEditor():
   """Conveniently edit the parameters of a lucid model.
-
   Example usage:
-
     model = models.InceptionV1()
     param = ParameterEditor(model.graph_def)
     # Flip weights of first channel of conv2d0
     param["conv2d0_w", :, :, :, 0] *= -1
-
   """
 
   def __init__(self, graph_def):
@@ -20,7 +17,7 @@ class ParameterEditor():
       if "value" in node.attr:
         self.nodes[str(node.name)] = node
     # Set a flag to mark the fact that this is an edited model
-    if not "lucid_edited_model_flag" in self.nodes:
+    if not "lucid_is_edited" in self.nodes:
       with tf.Graph().as_default() as temp_graph:
         const = tf.constant(True, name="lucid_is_edited")
         const_node = temp_graph.as_graph_def().node[0]
@@ -37,7 +34,7 @@ class ParameterEditor():
   def __setitem__(self, key, new_value):
     name = key[0] if isinstance(key, tuple) else key
     tensor = self.nodes[name].attr["value"].tensor
-    node_shape = [int(d.size) for d in tensor.tensor_shape.dim]
+    node_shape = tuple([int(d.size) for d in tensor.tensor_shape.dim])
     if isinstance(key, tuple):
       array = np.frombuffer(tensor.tensor_content, dtype="float32")
       array = array.reshape(node_shape).copy()
@@ -45,4 +42,5 @@ class ParameterEditor():
       tensor.tensor_content = array.tostring()
     else:
       assert new_value.shape == node_shape
-      tensor.tensor_content = new_value.tostring()
+      dtype = tf.DType(tensor.dtype).as_numpy_dtype
+      tensor.tensor_content = new_value.astype(dtype).tostring()


### PR DESCRIPTION
Makes a few fixes to `scratch/parameter_editor.py`:

- Model flag typo
- Convert tensor shape to tuple so comparison works
- Convert tensor value to original dtype