### PR TITLE
Add memory efficient model.get_activations()

### DIFF
--- a/lucid/misc/iter_nd_utils.py
+++ b/lucid/misc/iter_nd_utils.py
@@ -1,0 +1,93 @@
+# Copyright 2018 The Lucid Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Helpers for doing gnerator/iterable style workflows in n-dimensions."""
+
+import itertools
+import types
+from collections.abc import Iterable
+import numpy as np
+
+
+def recursive_enumerate_nd(it, stop_iter=None, prefix=()):
+  """Recursively enumerate nested iterables with tuples n-dimenional indices.
+
+  Arguments:
+    it: object to be enumerated
+    stop_iter: User defined funciton which can conditionally block further
+      iteration. Defaults to allowing iteration.
+    prefix: index prefix (not intended for end users)
+
+  Yields:
+    (tuple representing n-dimensional index, original iterator value)
+
+  Example use:
+    it = ((x+y for y in range(10) )
+               for x in range(10) )
+    recursive_enumerate_nd(it) # yields things like ((9,9), 18)
+
+  Example stop_iter:
+    stop_iter = lambda x: isinstance(x, np.ndarray) and len(x.shape) <= 3
+    # this prevents iteration into the last three levels (eg. x,y,channels) of
+    # a numpy ndarray
+
+  """
+  if stop_iter is None:
+    stop_iter = lambda x: False
+
+  for n, x in enumerate(it):
+    n_ = prefix + (n,)
+    if isinstance(x, Iterable) and (not stop_iter(x)):
+      yield from recursive_enumerate_nd(x, stop_iter=stop_iter, prefix=n_)
+    else:
+      yield (n_, x)
+
+
+def dict_to_ndarray(d):
+  """Convert a dictionary representation of an array (keys as indices) into a ndarray.
+
+  Args:
+    d: dict to be converted.
+
+  Converts a dictionary representation of a sparse array into a ndarray. Array
+  shape infered from maximum indices. Entries default to zero if unfilled.
+
+  Example:
+    >>> dict_to_ndarray({(0,0) : 3, (1,1) : 7})
+    [[3, 0],
+     [0, 7]]
+
+  """
+  inds = list(d.keys())
+  ind_dims = len(inds[0])
+  assert all(len(ind) == ind_dims for ind in inds)
+  ind_shape = [max(ind[i]+1 for ind in inds) for i in range(ind_dims)]
+  arr = None
+  for ind, val in d.items():
+    if arr is None:
+      if isinstance(val, np.ndarray):
+        arr = np.zeros(ind_shape + list(val.shape), dtype=val.dtype)
+      else:
+        arr = np.zeros(ind_shape, dtype="float32")
+    arr[ind] = val
+  return arr
+
+
+def batch_iter(it, batch_size=64):
+  """Iterate through an iterable object in batches."""
+  while True:
+    batch = list(itertools.islice(it, batch_size))
+    if not batch: break
+    yield batch

--- a/lucid/misc/iter_nd_utils.py
+++ b/lucid/misc/iter_nd_utils.py
@@ -70,17 +70,19 @@ def dict_to_ndarray(d):
      [0, 7]]
 
   """
+  assert len(d), "Dictionary passed to dict_to_ndarray() must not be empty."
   inds = list(d.keys())
   ind_dims = len(inds[0])
   assert all(len(ind) == ind_dims for ind in inds)
   ind_shape = [max(ind[i]+1 for ind in inds) for i in range(ind_dims)]
-  arr = None
+
+  val0  = d[inds[0]]
+  if isinstance(val0, np.ndarray):
+    arr = np.zeros(ind_shape + list(val0.shape), dtype=val0.dtype)
+  else:
+    arr = np.zeros(ind_shape, dtype="float32")
+
   for ind, val in d.items():
-    if arr is None:
-      if isinstance(val, np.ndarray):
-        arr = np.zeros(ind_shape + list(val.shape), dtype=val.dtype)
-      else:
-        arr = np.zeros(ind_shape, dtype="float32")
     arr[ind] = val
   return arr
 

--- a/lucid/modelzoo/get_activations.py
+++ b/lucid/modelzoo/get_activations.py
@@ -1,0 +1,170 @@
+# Copyright 2018 The Lucid Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Helpers for getting responses from models over large collections."""
+
+
+import itertools
+from collections import defaultdict
+
+import numpy as np
+import tensorflow as tf
+
+from lucid.misc.iter_nd_utils import recursive_enumerate_nd, dict_to_ndarray, batch_iter
+
+
+def get_activations_iter(model, layer, generator, reducer="mean", batch_size=64,
+                         dtype=None, ind_shape=None, center_only=False):
+  """Collect center activtions of a layer over many images from an iterable obj.
+
+  Note: this is mostly intended for large synthetic families of images, where
+    you can cheaply generate them in Python. For collecting activations over,
+    say, ImageNet, there will be better workflows based on various dataset APIs
+    in TensorFlow.
+
+  Args:
+    model: model for activations to be collected from.
+    layer: layer (in model) for activtions to be collected from.
+    generator: An iterable object (intended to be a generator) which produces
+      tuples of the form (index, image). See details below.
+    reducer: How to combine activations if multiple images map to the same index.
+      Supports "mean", "rms", and "max".
+    batch_size: How many images from the generator should be processes at once?
+    dtype: determines dtype of returned data (defaults to model activation
+      dtype). Can be used to make funciton memory efficient.
+    ind_shape: Shape that indices can span. Optional, but makes funciton orders
+      of magnitiude more memory efficient.
+
+  Memory efficeincy:
+    Using ind_shape is the main tool for make this function memory efficient.
+    dtype="float16" can further help.
+
+  Returns:
+    A numpy array of shape [ind1, ind2, ..., layer_channels]
+  """
+
+
+  assert reducer in ["mean", "max", "rms"]
+  combiner, normalizer = {
+      "mean" : (lambda a,b: a+b,             lambda a,n: a/n         ),
+      "rms"  : (lambda a,b: a+b**2,          lambda a,n: np.sqrt(a/n)),
+      "max"  : (lambda a,b: np.maximum(a,b), lambda a,n: a           ),
+  }[reducer]
+
+  with tf.Graph().as_default(), tf.Session() as sess:
+    t_img = tf.placeholder("float32", [None, None, None, 3])
+    T = model.import_graph(t_img)
+    t_layer = T(layer)
+
+    responses = None
+    count = None
+
+    # # If we know the total length, let's give a progress bar
+    # if ind_shape is not None:
+    #   total = int(np.prod(ind_shape))
+    #   generator = tqdm(generator, total=total)
+
+    for batch in batch_iter(generator, batch_size=batch_size):
+
+      inds, imgs = [x[0] for x in batch], [x[1] for x in batch]
+
+      # Get activations (middle of image)
+      acts = t_layer.eval({t_img: imgs})
+      if center_only:
+        acts = acts[:, acts.shape[1]//2, acts.shape[2]//2]
+      if dtype is not None:
+        acts = acts.astype(dtype)
+
+      # On the first iteration of the loop, create objects to hold responses
+      # (we wanted to know acts.shape[-1] before creating it in the numpy case)
+      if responses is None:
+        # If we don't know what the extent of the indices will be in advance
+        # we need to use a dictionary to support dynamic range
+        if ind_shape is None:
+          responses = {}
+          count = defaultdict(lambda: 0)
+        # But if we do, we can use a much more efficient numpy array
+        else:
+          responses = np.zeros(list(ind_shape) + list(acts.shape[1:]),
+                               dtype=acts.dtype)
+          count = np.zeros(ind_shape, dtype=acts.dtype)
+
+
+      # Store each batch item in appropriate index, performing reduction
+      for ind, act in zip(inds, acts):
+        count[ind] += 1
+        if ind in responses:
+          responses[ind] = combiner(responses[ind], act)
+        else:
+          responses[ind] = act
+
+  # complete reduction as necessary, then return
+  # First the case where everything is in numpy
+  if isinstance(responses, np.ndarray):
+    count = np.maximum(count, 1e-6)[..., None]
+    return normalizer(responses, count)
+  # Then the dynamic shape dictionary case
+  else:
+    for k in responses:
+      count_ = np.maximum(count[k], 1e-6)[None].astype(acts.dtype)
+      responses[k] = normalizer(responses[k], count_)
+    return dict_to_ndarray(responses)
+
+
+def get_activations(model, layer, examples, batch_size=64,
+                       dtype=None, ind_shape=None, center_only=False):
+  """Collect center activtions of a layer over an n-dimensional array of images.
+
+  Note: this is mostly intended for large synthetic families of images, where
+    you can cheaply generate them in Python. For collecting activations over,
+    say, ImageNet, there will be better workflows based on various dataset APIs
+    in TensorFlow.
+
+  Args:
+    model: model for activations to be collected from.
+    layer: layer (in model) for activtions to be collected from.
+    examples: A (potentially n-dimensional) array of images. Can be any nested
+      iterable object, including a generator, as long as the inner most objects
+      are a numpy array with at least 3 dimensions (image X, Y, channels=3).
+    batch_size: How many images should be processed at once?
+    dtype: determines dtype of returned data (defaults to model activation
+      dtype). Can be used to make funciton memory efficient.
+    ind_shape: Shape that the index (non-image) dimensions of examples. Makes
+      code much more memory efficient if examples is not a numpy array.
+
+  Memory efficeincy:
+    Have examples be a generator rather than an array of images; this allows
+    them to be lazily generated and not all stored in memory at once. Also
+    use ind_shape so that activations can be stored in an efficient data
+    structure. If you still have memory problems, dtype="float16" can probably
+    get you another 2x.
+
+  Returns:
+    A numpy array of shape [ind1, ind2, ..., layer_channels]
+  """
+
+
+  if ind_shape is None and isinstance(examples, np.ndarray):
+    ind_shape = examples.shape[:-3]
+
+  # Create a generator which recursive enumerates examples, stoppping at
+  # the third last dimesnion (ie. an individual iamge) if numpy arrays.
+  examples_enumerated = recursive_enumerate_nd(examples,
+    stop_iter = lambda x: isinstance(x, np.ndarray) and len(x.shape) <= 3)
+
+  # Get responses
+  return get_activations_iter(model, layer, examples_enumerated,
+                            batch_size=batch_size, dtype=dtype,
+                            ind_shape=ind_shape, center_only=center_only)

--- a/lucid/modelzoo/get_activations.py
+++ b/lucid/modelzoo/get_activations.py
@@ -43,8 +43,8 @@ def get_activations_iter(model, layer, generator, reducer="mean", batch_size=64,
       Supports "mean", "rms", and "max".
     batch_size: How many images from the generator should be processes at once?
     dtype: determines dtype of returned data (defaults to model activation
-      dtype). Can be used to make funciton memory efficient.
-    ind_shape: Shape that indices can span. Optional, but makes funciton orders
+      dtype). Can be used to make function memory efficient.
+    ind_shape: Shape that indices can span. Optional, but makes function orders
       of magnitiude more memory efficient.
 
   Memory efficeincy:
@@ -140,7 +140,7 @@ def get_activations(model, layer, examples, batch_size=64,
       are a numpy array with at least 3 dimensions (image X, Y, channels=3).
     batch_size: How many images should be processed at once?
     dtype: determines dtype of returned data (defaults to model activation
-      dtype). Can be used to make funciton memory efficient.
+      dtype). Can be used to make function memory efficient.
     ind_shape: Shape that the index (non-image) dimensions of examples. Makes
       code much more memory efficient if examples is not a numpy array.
 

--- a/lucid/modelzoo/vision_base.py
+++ b/lucid/modelzoo/vision_base.py
@@ -24,7 +24,7 @@ import numpy as np
 
 from lucid.modelzoo import util as model_util
 from lucid.modelzoo.aligned_activations import get_aligned_activations as _get_aligned_activations
-from lucid.modelzoo.get_activations import get_activations
+from lucid.modelzoo.get_activations import get_activations as _get_activations
 from lucid.misc.io import load, save
 import lucid.misc.io.showing as showing
 
@@ -375,7 +375,7 @@ class Model():
         are a numpy array with at least 3 dimensions (image X, Y, channels=3).
       batch_size: How many images should be processed at once?
       dtype: determines dtype of returned data (defaults to model activation
-        dtype). Can be used to make funciton memory efficient.
+        dtype). Can be used to make function memory efficient.
       ind_shape: Shape that the index (non-image) dimensions of examples. Makes
         code much more memory efficient if examples is not a numpy array.
 
@@ -390,9 +390,9 @@ class Model():
       A numpy array of shape [ind1, ind2, ..., layer_channels]
     """
 
-    return get_activations(self, layer, examples, batch_size=batch_size,
-                           dtype=dtype, ind_shape=ind_shape,
-                           center_only=center_only)
+    return _get_activations(self, layer, examples, batch_size=batch_size,
+                            dtype=dtype, ind_shape=ind_shape,
+                            center_only=center_only)
 
 
 class SerializedModel(Model):

--- a/lucid/optvis/render.py
+++ b/lucid/optvis/render.py
@@ -79,7 +79,7 @@ def render_vis(model, objective_f, param_f=None, optimizer=None,
     use_fixed_seed: Seed the RNG with a fixed value so results are reproducible.
       Off by default. As of tf 1.8 this does not work as intended, see:
       https://github.com/tensorflow/tensorflow/issues/9171
-  
+
   Returns:
     2D array of optimization results containing of evaluations of supplied
     param_f snapshotted at specified thresholds. Usually that will mean one or
@@ -254,14 +254,11 @@ def import_model(model, t_image, t_image_raw=None, scope="import", input_map=Non
   if t_image_raw is None:
     t_image_raw = t_image
 
-  model.import_graph(t_image, scope=scope, forget_xy_shape=True, input_map=input_map)
+  T_ = model.import_graph(t_image, scope=scope, forget_xy_shape=True, input_map=input_map)
 
   def T(layer):
     if layer == "input": return t_image_raw
     if layer == "labels": return model.labels
-    if ":" in layer:
-        return t_image.graph.get_tensor_by_name("%s/%s" % (scope,layer))
-    else:
-        return t_image.graph.get_tensor_by_name("%s/%s:0" % (scope,layer))
+    return T_(layer)
 
   return T


### PR DESCRIPTION
The goal of this PR is to add a `model.get_activations()` function which can get activations for large n-dimensional families of lazily generated images. In the course of accomplishing this, I had to do a few other things:

(1) Add a number of utilities for using iterable workflows in n-dimensions. See `lucid.misc.iter_nd_utils`.

(2) Fix an annoying cludge with `model.import_graph()`. Lucid's convention for accessing the internals of an imported model is to use the `T()` accessor (inspired by `$` in jquery). But for weird historical reasons, only `render.import_model` returned `T`, not `model.import_graph`. To avoid needing to depend on `render`, I added this support to `import_graph` (where it really always should have been).

(3) Finally, add a lazy iteration based `get_activations` and `get_activations_iter` (more flexible, but not exposed by default). `get_activations()` is added as a method to model to make it easily accessible.