### PR TITLE
[*.py] Rename "Arguments:" to "Args:"

### DIFF
--- a/lucid/misc/iter_nd_utils.py
+++ b/lucid/misc/iter_nd_utils.py
@@ -24,7 +24,7 @@ import numpy as np
 def recursive_enumerate_nd(it, stop_iter=None, prefix=()):
   """Recursively enumerate nested iterables with tuples n-dimenional indices.
 
-  Arguments:
+  Args:
     it: object to be enumerated
     stop_iter: User defined funciton which can conditionally block further
       iteration. Defaults to allowing iteration.

--- a/lucid/misc/stimuli.py
+++ b/lucid/misc/stimuli.py
@@ -50,7 +50,7 @@ def sample_binary_image(size, alias_factor=10, color_a=(1,1,1), color_b=(0,0,0),
         return (negative if interior, positive if exterior)
       img = sampler(img_f)
 
-  Arguments:
+  Args:
     size: Size of image to be rendered in pixels.
     alias_factor: Number of samples to use in aliasing.
     color_a: Color of exterior. A 3-tuple of floats between 0 and 1. Defaults
@@ -148,7 +148,7 @@ def rounded_corner(orientation, r, angular_width=90, size=224, **kwds):
   This function is a flexible generator of "rounded corner" stimuli. It returns
   an image, represented as a numpy array of shape [size, size, 3].
 
-  Arguments:
+  Args:
     orientation: The orientation of the curve, in degrees.
     r: radius of the curve
     angular_width: when r=0 and we have sharp corner, this controls the angle


### PR DESCRIPTION
I've written custom parsers and emitters for everything from docstrings to classes and functions. However, I recently came across an issue with the TensorFlow codebase: inconsistent use of `Args:` and `Arguments:` in its docstrings. It is easy enough to extend my parsers to support both variants, however it looks like `Arguments:` is wrong anyway, as per:

  - https://google.github.io/styleguide/pyguide.html#doc-function-args @ [`ddccc0f`](https://github.com/google/styleguide/blob/ddccc0f/pyguide.md)

  - https://chromium.googlesource.com/chromiumos/docs/+/master/styleguide/python.md#describing-arguments-in-docstrings @ [`9fc0fc0`](https://chromium.googlesource.com/chromiumos/docs/+/9fc0fc0/styleguide/python.md)

  - https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html @ [`c0ae8e3`](https://github.com/sphinx-contrib/napoleon/blob/c0ae8e3/docs/source/example_google.rst)

Therefore, only `Args:` is valid. This PR replaces them throughout the codebase.

PS: For related PRs, see tensorflow/tensorflow/pull/45420