### PR TITLE
Update show() to fix Firefox rendering issue

### DIFF
--- a/lucid/misc/io/showing.py
+++ b/lucid/misc/io/showing.py
@@ -61,7 +61,7 @@ def _image_url(array, fmt='png', mode="data", quality=90, domain=None):
 
 def _image_html(array, w=None, domain=None, fmt='png'):
   url = _image_url(array, domain=domain, fmt=fmt)
-  style = "image-rendering: pixelated;"
+  style = "image-rendering: pixelated; image-rendering: crisp-edges;"
   if w is not None:
     style += "width: {w}px;".format(w=w)
   return """<img src="{url}" style="{style}">""".format(**locals())


### PR DESCRIPTION
Sometimes Colab images rendered using `show()` are blurry when viewed in Firefox.

This commit fixes this by updating the CSS in `show()` so that it uses `image-rendering: pixelated; image-rendering: crisp-edges;` for fallback Firefox compatibility.