### PR TITLE
Remove broken image link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-<img src="https://storage.googleapis.com/lucid-static/common/stickers/channels-visualizations.jpg" width="782"></img>
-
 # Lucid
 
 <!--*DeepDream, but sane. Home of cats, dreams, and interpretable neural networks.*-->


### PR DESCRIPTION
The first image on the readme is missing:
<img src="https://user-images.githubusercontent.com/45014214/122642353-147a3a00-d0d8-11eb-9c51-5f06f8590e93.png" width="400"></img>

When I go to the link to the image in the README https://storage.googleapis.com/lucid-static/common/stickers/channels-visualizations.jpg
There is an error there as well : `NoSuchBucket`

Until we fix this, we should remove this image from the README